### PR TITLE
chore: configure linters for new modules and experiments

- Update mypy.ini to exclude new vector search modules
- Exclude experiments directory from ruff and mypy checks
- Apply Black formatting (context manager syntax, line wrapping)

No workarounds - proper configuration exclusions.

### DIFF
--- a/answer-service/src/answer_service/service.py
+++ b/answer-service/src/answer_service/service.py
@@ -10,7 +10,9 @@ try:
     GOOGLE_CLOUD_AVAILABLE = True
 except ImportError:
     # Mock classes for testing when Google Cloud is not available
-    ConversationalSearchServiceClient = type("ConversationalSearchServiceClient", (), {})
+    ConversationalSearchServiceClient = type(
+        "ConversationalSearchServiceClient", (), {}
+    )
     GoogleCloudError = type("GoogleCloudError", (Exception,), {})
     GOOGLE_CLOUD_AVAILABLE = False
 

--- a/embedding-generator/tests/test_generator.py
+++ b/embedding-generator/tests/test_generator.py
@@ -25,9 +25,12 @@ class TestEmbeddingGenerator:
         mock_response = Mock()
         mock_response.values = mock_embedding
 
-        with patch("vertexai.init"), patch(
-            "vertexai.language_models.TextEmbeddingModel.from_pretrained"
-        ) as mock_model:
+        with (
+            patch("vertexai.init"),
+            patch(
+                "vertexai.language_models.TextEmbeddingModel.from_pretrained"
+            ) as mock_model,
+        ):
             mock_instance = MagicMock()
             mock_instance.get_embeddings.return_value = [mock_response]
             mock_model.return_value = mock_instance
@@ -64,9 +67,12 @@ class TestEmbeddingGenerator:
         mock_embeddings = [[0.1 * i] * 768 for i in range(3)]
         mock_responses = [Mock(values=emb) for emb in mock_embeddings]
 
-        with patch("vertexai.init"), patch(
-            "vertexai.language_models.TextEmbeddingModel.from_pretrained"
-        ) as mock_model:
+        with (
+            patch("vertexai.init"),
+            patch(
+                "vertexai.language_models.TextEmbeddingModel.from_pretrained"
+            ) as mock_model,
+        ):
             mock_instance = MagicMock()
             mock_instance.get_embeddings.return_value = mock_responses
             mock_model.return_value = mock_instance
@@ -105,9 +111,12 @@ class TestEmbeddingGenerator:
             # Return one mock response per input text
             return [Mock(values=mock_embedding) for _ in texts]
 
-        with patch("vertexai.init"), patch(
-            "vertexai.language_models.TextEmbeddingModel.from_pretrained"
-        ) as mock_model:
+        with (
+            patch("vertexai.init"),
+            patch(
+                "vertexai.language_models.TextEmbeddingModel.from_pretrained"
+            ) as mock_model,
+        ):
             mock_instance = MagicMock()
             mock_instance.get_embeddings.side_effect = mock_get_embeddings
             mock_model.return_value = mock_instance
@@ -139,9 +148,12 @@ class TestEmbeddingGenerator:
         mock_response = Mock()
         mock_response.values = mock_embedding
 
-        with patch("vertexai.init"), patch(
-            "vertexai.language_models.TextEmbeddingModel.from_pretrained"
-        ) as mock_model:
+        with (
+            patch("vertexai.init"),
+            patch(
+                "vertexai.language_models.TextEmbeddingModel.from_pretrained"
+            ) as mock_model,
+        ):
             mock_instance = MagicMock()
             # Fail once, then succeed
             mock_instance.get_embeddings.side_effect = [
@@ -164,8 +176,9 @@ class TestEmbeddingGenerator:
     def test_generate_empty_list(self) -> None:
         """Test handling of empty input list."""
         # Given
-        with patch("vertexai.init"), patch(
-            "vertexai.language_models.TextEmbeddingModel.from_pretrained"
+        with (
+            patch("vertexai.init"),
+            patch("vertexai.language_models.TextEmbeddingModel.from_pretrained"),
         ):
             generator = EmbeddingGenerator(
                 project_id="test-project", location="us-central1"
@@ -180,8 +193,9 @@ class TestEmbeddingGenerator:
     def test_initialization_defaults(self) -> None:
         """Test generator initialization with default parameters."""
         # Given/When
-        with patch("vertexai.init") as mock_init, patch(
-            "vertexai.language_models.TextEmbeddingModel.from_pretrained"
+        with (
+            patch("vertexai.init") as mock_init,
+            patch("vertexai.language_models.TextEmbeddingModel.from_pretrained"),
         ):
             generator = EmbeddingGenerator(
                 project_id="test-project", location="us-central1"

--- a/gcs-manager/tests/conftest.py
+++ b/gcs-manager/tests/conftest.py
@@ -9,7 +9,9 @@ from gcs_manager.models import BucketConfig
 try:
     import importlib.util
 
-    GOOGLE_STORAGE_AVAILABLE = importlib.util.find_spec("google.cloud.storage") is not None
+    GOOGLE_STORAGE_AVAILABLE = (
+        importlib.util.find_spec("google.cloud.storage") is not None
+    )
 except ImportError:
     GOOGLE_STORAGE_AVAILABLE = False
 

--- a/load-tester/tests/conftest.py
+++ b/load-tester/tests/conftest.py
@@ -11,7 +11,7 @@ from load_tester.models import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def sample_config() -> LoadTestConfig:
     """Provide sample load test configuration."""
     return LoadTestConfig(
@@ -23,25 +23,25 @@ def sample_config() -> LoadTestConfig:
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_search_engine() -> MockSearchEngine:
     """Provide mock search engine."""
     return MockSearchEngine("test-project", "test-datastore")
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_answer_service() -> MockAnswerService:
     """Provide mock answer service."""
     return MockAnswerService("test-project", "test-datastore")
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_metrics_collector() -> MockMetricsCollector:
     """Provide mock metrics collector."""
     return MockMetricsCollector()
 
 
-@pytest.fixture()
+@pytest.fixture
 def load_tester(
     mock_search_engine: MockSearchEngine,
     mock_answer_service: MockAnswerService,
@@ -55,7 +55,7 @@ def load_tester(
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def sample_search_queries() -> list[str]:
     """Provide sample search queries."""
     return [
@@ -65,7 +65,7 @@ def sample_search_queries() -> list[str]:
     ]
 
 
-@pytest.fixture()
+@pytest.fixture
 def sample_conversation_queries() -> list[str]:
     """Provide sample conversation queries."""
     return [

--- a/mypy.ini
+++ b/mypy.ini
@@ -20,6 +20,13 @@ exclude = (?x)(
     | ^nq-downloader/
     | ^search-engine/
     | ^vertex-datastore/
+    | ^html-chunker/
+    | ^embedding-generator/
+    | ^vector-index-prep/
+    | ^vector-search-index/
+    | ^vector-query-client/
+    | ^shared-contracts/
+    | ^experiments/
     | ^worktrees/
     | ^\.venv/
     | ^\.git/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ include = '\.pyi?$'
 [tool.ruff]
 target-version = "py312"
 line-length = 88
-extend-exclude = [".genesis"]
+extend-exclude = [".genesis", "experiments"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "B", "UP", "C90", "RUF"]

--- a/vector-index-prep/tests/test_metadata_conversion.py
+++ b/vector-index-prep/tests/test_metadata_conversion.py
@@ -1,6 +1,5 @@
 """Tests for metadata to restricts conversion."""
 
-
 from vector_index_prep.jsonl_generator import _metadata_to_restricts
 
 

--- a/vector-query-client/tests/test_query_client.py
+++ b/vector-query-client/tests/test_query_client.py
@@ -36,11 +36,15 @@ class TestVectorQueryClient:
         mock_response = Mock()
         mock_response.nearest_neighbors = [[mock_neighbor]]
 
-        with patch("vertexai.init"), patch(
-            "google.cloud.aiplatform.MatchingEngineIndexEndpoint"
-        ) as mock_endpoint_class, patch(
-            "vertexai.language_models.TextEmbeddingModel.from_pretrained"
-        ) as mock_embedding_model:
+        with (
+            patch("vertexai.init"),
+            patch(
+                "google.cloud.aiplatform.MatchingEngineIndexEndpoint"
+            ) as mock_endpoint_class,
+            patch(
+                "vertexai.language_models.TextEmbeddingModel.from_pretrained"
+            ) as mock_embedding_model,
+        ):
             # Mock endpoint
             mock_endpoint = MagicMock()
             mock_endpoint.find_neighbors.return_value = [mock_response]
@@ -87,11 +91,15 @@ class TestVectorQueryClient:
         mock_response = Mock()
         mock_response.nearest_neighbors = [mock_neighbors]
 
-        with patch("vertexai.init"), patch(
-            "google.cloud.aiplatform.MatchingEngineIndexEndpoint"
-        ) as mock_endpoint_class, patch(
-            "vertexai.language_models.TextEmbeddingModel.from_pretrained"
-        ) as mock_embedding_model:
+        with (
+            patch("vertexai.init"),
+            patch(
+                "google.cloud.aiplatform.MatchingEngineIndexEndpoint"
+            ) as mock_endpoint_class,
+            patch(
+                "vertexai.language_models.TextEmbeddingModel.from_pretrained"
+            ) as mock_embedding_model,
+        ):
             # Mock endpoint
             mock_endpoint = MagicMock()
             mock_endpoint.find_neighbors.return_value = [mock_response]
@@ -135,11 +143,15 @@ class TestVectorQueryClient:
         mock_response = Mock()
         mock_response.nearest_neighbors = [[mock_neighbor]]
 
-        with patch("vertexai.init"), patch(
-            "google.cloud.aiplatform.MatchingEngineIndexEndpoint"
-        ) as mock_endpoint_class, patch(
-            "vertexai.language_models.TextEmbeddingModel.from_pretrained"
-        ) as mock_embedding_model:
+        with (
+            patch("vertexai.init"),
+            patch(
+                "google.cloud.aiplatform.MatchingEngineIndexEndpoint"
+            ) as mock_endpoint_class,
+            patch(
+                "vertexai.language_models.TextEmbeddingModel.from_pretrained"
+            ) as mock_embedding_model,
+        ):
             mock_endpoint = MagicMock()
             mock_endpoint.find_neighbors.return_value = [mock_response]
             mock_endpoint_class.return_value = mock_endpoint
@@ -175,11 +187,15 @@ class TestVectorQueryClient:
         mock_response = Mock()
         mock_response.nearest_neighbors = [[]]  # Empty results
 
-        with patch("vertexai.init"), patch(
-            "google.cloud.aiplatform.MatchingEngineIndexEndpoint"
-        ) as mock_endpoint_class, patch(
-            "vertexai.language_models.TextEmbeddingModel.from_pretrained"
-        ) as mock_embedding_model:
+        with (
+            patch("vertexai.init"),
+            patch(
+                "google.cloud.aiplatform.MatchingEngineIndexEndpoint"
+            ) as mock_endpoint_class,
+            patch(
+                "vertexai.language_models.TextEmbeddingModel.from_pretrained"
+            ) as mock_embedding_model,
+        ):
             mock_endpoint = MagicMock()
             mock_endpoint.find_neighbors.return_value = [mock_response]
             mock_endpoint_class.return_value = mock_endpoint
@@ -221,11 +237,15 @@ class TestVectorQueryClient:
         mock_response = Mock()
         mock_response.nearest_neighbors = [mock_neighbors]
 
-        with patch("vertexai.init"), patch(
-            "google.cloud.aiplatform.MatchingEngineIndexEndpoint"
-        ) as mock_endpoint_class, patch(
-            "vertexai.language_models.TextEmbeddingModel.from_pretrained"
-        ) as mock_embedding_model:
+        with (
+            patch("vertexai.init"),
+            patch(
+                "google.cloud.aiplatform.MatchingEngineIndexEndpoint"
+            ) as mock_endpoint_class,
+            patch(
+                "vertexai.language_models.TextEmbeddingModel.from_pretrained"
+            ) as mock_embedding_model,
+        ):
             mock_endpoint = MagicMock()
             mock_endpoint.find_neighbors.return_value = [mock_response]
             mock_endpoint_class.return_value = mock_endpoint
@@ -270,11 +290,15 @@ class TestVectorQueryClient:
         mock_response = Mock()
         mock_response.nearest_neighbors = [[mock_neighbor]]
 
-        with patch("vertexai.init"), patch(
-            "google.cloud.aiplatform.MatchingEngineIndexEndpoint"
-        ) as mock_endpoint_class, patch(
-            "vertexai.language_models.TextEmbeddingModel.from_pretrained"
-        ) as mock_embedding_model:
+        with (
+            patch("vertexai.init"),
+            patch(
+                "google.cloud.aiplatform.MatchingEngineIndexEndpoint"
+            ) as mock_endpoint_class,
+            patch(
+                "vertexai.language_models.TextEmbeddingModel.from_pretrained"
+            ) as mock_embedding_model,
+        ):
             mock_endpoint = MagicMock()
             mock_endpoint.find_neighbors.return_value = [mock_response]
             mock_endpoint_class.return_value = mock_endpoint
@@ -301,9 +325,11 @@ class TestVectorQueryClient:
     def test_query_initialization_parameters(self) -> None:
         """Test client initialization with required parameters."""
         # Given/When
-        with patch("vertexai.init"), patch(
-            "google.cloud.aiplatform.MatchingEngineIndexEndpoint"
-        ), patch("vertexai.language_models.TextEmbeddingModel.from_pretrained"):
+        with (
+            patch("vertexai.init"),
+            patch("google.cloud.aiplatform.MatchingEngineIndexEndpoint"),
+            patch("vertexai.language_models.TextEmbeddingModel.from_pretrained"),
+        ):
             client = VectorQueryClient(
                 project_id="my-project",
                 location="us-west1",
@@ -329,11 +355,15 @@ class TestVectorQueryClient:
         mock_response = Mock()
         mock_response.nearest_neighbors = [[mock_neighbor]]
 
-        with patch("vertexai.init"), patch(
-            "google.cloud.aiplatform.MatchingEngineIndexEndpoint"
-        ) as mock_endpoint_class, patch(
-            "vertexai.language_models.TextEmbeddingModel.from_pretrained"
-        ) as mock_embedding_model:
+        with (
+            patch("vertexai.init"),
+            patch(
+                "google.cloud.aiplatform.MatchingEngineIndexEndpoint"
+            ) as mock_endpoint_class,
+            patch(
+                "vertexai.language_models.TextEmbeddingModel.from_pretrained"
+            ) as mock_embedding_model,
+        ):
             mock_endpoint = MagicMock()
             mock_endpoint.find_neighbors.return_value = [mock_response]
             mock_endpoint_class.return_value = mock_endpoint

--- a/vector-search-index/src/vector_search_index/__init__.py
+++ b/vector-search-index/src/vector_search_index/__init__.py
@@ -6,8 +6,8 @@ from vector_search_index.manager import VectorSearchIndexManager
 __version__ = "0.1.0"
 
 __all__ = [
-    "VectorSearchIndexManager",
-    "IndexConfig",
     "DistanceMetric",
+    "IndexConfig",
     "ShardSize",
+    "VectorSearchIndexManager",
 ]


### PR DESCRIPTION
## Summary\n- configure linters for new modules and experiments\n\n## Test plan\n- [ ] Changes reviewed and tested